### PR TITLE
Support dispatching actions in parallel thread

### DIFF
--- a/rxredux/src/main/java/com/mercari/rxredux/RxRedux.kt
+++ b/rxredux/src/main/java/com/mercari/rxredux/RxRedux.kt
@@ -45,13 +45,16 @@ interface StoreType<S : State, A : Action> {
 class Store<S : State, A : Action>(
         initialState: S,
         reducer: Reducer<S, A>,
-        defaultScheduler: Scheduler = Schedulers.single()
+        defaultScheduler: Scheduler = Schedulers.single(),
+        serializeActions: Boolean = false
 ) : StoreType<S, A> {
 
     // seed action
     private object NoAction : Action
 
-    private val actionSubject = PublishSubject.create<A>()
+    private val actionSubject = PublishSubject.create<A>().let {
+        if (serializeActions) it.toSerialized() else it
+    }
 
     override val states: Observable<S>
         get() = _states.distinctUntilChanged()

--- a/rxredux/src/test/java/com/mercari/rxredux/MultiThreadTest.kt
+++ b/rxredux/src/test/java/com/mercari/rxredux/MultiThreadTest.kt
@@ -1,0 +1,55 @@
+package com.mercari.rxredux
+
+import io.reactivex.Observable
+import org.amshove.kluent.shouldBe
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.atomic.AtomicInteger
+
+object MultiThreadTest : Spek({
+
+    val counterState = CounterState()
+
+    val counterReducer = object : Reducer<CounterState, CounterAction> {
+        override fun reduce(currentState: CounterState, action: CounterAction): CounterState {
+            val counter = currentState.counter
+            return when (action) {
+                is Increment -> currentState.copy(counter = counter + action.by)
+                is Decrement -> currentState.copy(counter = counter - action.by)
+            }
+        }
+    }
+
+    describe("a redux store with default scheduler") {
+
+        val store = Store(counterState, counterReducer)
+        val test = store.states.test()
+        val errorCounter = AtomicInteger(0)
+
+        context("increment actions in parallel") {
+
+            MultiThreadTest.incrementCounter(store, errorCounter)
+            MultiThreadTest.incrementCounter(store, errorCounter)
+            MultiThreadTest.incrementCounter(store, errorCounter)
+            MultiThreadTest.incrementCounter(store, errorCounter)
+            MultiThreadTest.incrementCounter(store, errorCounter)
+
+            it("should no errors") {
+                test.await(5_000L, MILLISECONDS)
+                errorCounter.get() shouldBe 0
+            }
+        }
+    }
+}) {
+
+    private fun incrementCounter(store: Store<CounterState, CounterAction>, errorCounter: AtomicInteger) {
+        Observable.interval(0L, 10L, MILLISECONDS)
+            .subscribe({
+                store.dispatch(Increment(1))
+            }, {
+                it.printStackTrace()
+                errorCounter.incrementAndGet()
+            })
+    }
+}

--- a/rxredux/src/test/java/com/mercari/rxredux/MultiThreadTest.kt
+++ b/rxredux/src/test/java/com/mercari/rxredux/MultiThreadTest.kt
@@ -4,6 +4,7 @@ import io.reactivex.Observable
 import org.amshove.kluent.shouldBe
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.security.SecureRandom
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -29,11 +30,9 @@ object MultiThreadTest : Spek({
 
         context("increment actions in parallel") {
 
-            MultiThreadTest.incrementCounter(store, errorCounter)
-            MultiThreadTest.incrementCounter(store, errorCounter)
-            MultiThreadTest.incrementCounter(store, errorCounter)
-            MultiThreadTest.incrementCounter(store, errorCounter)
-            MultiThreadTest.incrementCounter(store, errorCounter)
+            repeat(10) {
+                MultiThreadTest.incrementCounter(store, errorCounter)
+            }
 
             it("should no errors") {
                 test.await(5_000L, MILLISECONDS)
@@ -44,11 +43,10 @@ object MultiThreadTest : Spek({
 }) {
 
     private fun incrementCounter(store: Store<CounterState, CounterAction>, errorCounter: AtomicInteger) {
-        Observable.interval(0L, 10L, MILLISECONDS)
+        Observable.interval(0L, SecureRandom().nextLong(), MILLISECONDS)
             .subscribe({
                 store.dispatch(Increment(1))
             }, {
-                it.printStackTrace()
                 errorCounter.incrementAndGet()
             })
     }


### PR DESCRIPTION
Store.actionSubject is defined as PublishSubject, but when actions are dispatched at the same time in other threads, an exception is thrown in ObservableReplay.

To solve this issue, I introduced SerializedSubject.
Also, in consideration of compatibility, switch between which is used in the constructor of Store.

I added tests to dispatch actions in multi-thread to check if it works.