### PR TITLE
Add CompositeReducer for the convenience to split a reducer into smaller chunk

### DIFF
--- a/rxredux/src/main/java/com/mercari/rxredux/CompositeReducer.kt
+++ b/rxredux/src/main/java/com/mercari/rxredux/CompositeReducer.kt
@@ -1,0 +1,13 @@
+package com.mercari.rxredux
+
+/**
+ * A reducer container that can have multiple other reducers.
+ * This will apply all [Reducer.reduce] operations associated with this sequentially.
+ */
+class CompositeReducer<S : State, A : Action>(
+  private val reducers: List<Reducer<S, A>>
+) : Reducer<S, A> {
+  override fun reduce(currentState: S, action: A): S = reducers.fold(currentState) { state, reducer ->
+    reducer.reduce(state, action)
+  }
+}

--- a/rxredux/src/test/java/com/mercari/rxredux/CompositeReducerTest.kt
+++ b/rxredux/src/test/java/com/mercari/rxredux/CompositeReducerTest.kt
@@ -1,0 +1,122 @@
+package com.mercari.rxredux
+
+import org.amshove.kluent.shouldEqual
+import org.amshove.kluent.shouldNotEqual
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.gherkin.Feature
+
+object CompositeReducerTest : Spek({
+
+  Feature("CompositeReducer") {
+
+    val compositeReducer: CompositeReducer<TestState, TestAction> = CompositeReducer(listOf(FooReducer(), BarReducer()))
+
+    Scenario("Reduce concat text action") {
+
+      lateinit var initialState: TestState
+      lateinit var nextState: TestState
+
+      Given("An initial state") {
+        initialState = TestState("A", 10, false)
+      }
+
+      When("Dispatch ConcatTextAction") {
+        nextState = compositeReducer.reduce(initialState, ConcatTextAction)
+      }
+
+      Then("Next state is different from initial state") {
+        nextState shouldNotEqual initialState
+      }
+
+      And("Next state text should have 2 'A's") {
+        nextState.text shouldEqual "AA"
+      }
+    }
+
+    Scenario("Reduce subtract number action") {
+
+      lateinit var initialState: TestState
+      lateinit var nextState: TestState
+
+      Given("An initial state") {
+        initialState = TestState("A", 10, false)
+      }
+
+      When("Dispatch SubtractNumberAction") {
+        nextState = compositeReducer.reduce(initialState, SubtractNumberAction)
+      }
+
+      Then("Next state is different from initial state") {
+        nextState shouldNotEqual initialState
+      }
+
+      And("Next state number should decrease") {
+        nextState.number shouldEqual 9
+      }
+    }
+
+    Scenario("Reduce toggle flag action") {
+
+      lateinit var initialState: TestState
+      lateinit var nextState: TestState
+
+      Given("An initial state") {
+        initialState = TestState("A", 10, false)
+      }
+
+      When("Dispatch ToggleFlagAction") {
+        nextState = compositeReducer.reduce(initialState, ToggleFlagAction)
+      }
+
+      Then("Next state is the same as initial state") {
+        nextState shouldEqual initialState
+      }
+    }
+  }
+})
+
+private data class TestState(
+  val text: String,
+  val number: Int,
+  val flag: Boolean
+) : State
+
+sealed class TestAction : Action
+
+object ConcatTextAction : TestAction()
+
+object SubtractNumberAction : TestAction()
+
+object ToggleFlagAction : TestAction()
+
+private class FooReducer : Reducer<TestState, TestAction> {
+  override fun reduce(currentState: TestState, action: TestAction): TestState = when (action) {
+    is ConcatTextAction -> {
+      currentState.copy(
+        text = currentState.text.plus("A")
+      )
+    }
+    is ToggleFlagAction -> {
+      currentState.copy(
+        flag = currentState.flag.not()
+      )
+    }
+    else -> currentState
+  }
+}
+
+private class BarReducer : Reducer<TestState, TestAction> {
+  override fun reduce(currentState: TestState, action: TestAction): TestState = when (action) {
+    is SubtractNumberAction -> {
+      currentState.copy(
+        number = currentState.number - 1
+      )
+    }
+    is ToggleFlagAction -> {
+      currentState.copy(
+        flag = currentState.flag.not()
+      )
+    }
+    else -> currentState
+  }
+}


### PR DESCRIPTION
With `CompositeReducer`, we can combine multiple reducers and use them for a `Store`.
This is convenient when a `Reducer` gets bigger and bigger and have multiple responsibilities on the associated `State`.