### PR TITLE
NoOpReducer for the convenience of having `no state change` reducer

### DIFF
--- a/rxredux/src/main/java/com/mercari/rxredux/NoOpReducer.kt
+++ b/rxredux/src/main/java/com/mercari/rxredux/NoOpReducer.kt
@@ -1,0 +1,8 @@
+package com.mercari.rxredux
+
+/**
+ * This reducer always returns the same state.
+ */
+class NoOpReducer<S : State, A : Action> : Reducer<S, A> {
+  override fun reduce(currentState: S, action: A): S = currentState
+}

--- a/rxredux/src/test/java/com/mercari/rxredux/NoOpReducerTest.kt
+++ b/rxredux/src/test/java/com/mercari/rxredux/NoOpReducerTest.kt
@@ -1,0 +1,35 @@
+package com.mercari.rxredux
+
+import org.amshove.kluent.shouldEqual
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.gherkin.Feature
+
+object NoOpReducerTest : Spek({
+
+  Feature("NoOpReducer") {
+
+    Scenario("Reducing the state with NoOpReducer") {
+
+      lateinit var reducer: NoOpReducer<TestState, TestAction>
+      lateinit var state: TestState
+      lateinit var newState: TestState
+
+      Given("Initialize NoOpReducer") {
+        reducer = NoOpReducer()
+        state = TestState()
+      }
+
+      When("Reduce the action") {
+        newState = reducer.reduce(state, TestAction)
+      }
+
+      Then("No state changes will happen") {
+        newState shouldEqual state
+      }
+    }
+  }
+})
+
+data class TestState(val meaningless: String = "meaningless") : State
+
+object TestAction : Action


### PR DESCRIPTION
`NoOpReducer` always returns the same state, convenient to have `no operation` for the state.