### PR TITLE
Use buildSrc to define versions and dependencies instead of gradle.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath(kotlin("gradle-plugin", extra.get("kotlinVersion") as String))
-        classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:${extra.get("bintrayVersion")}")
+        classpath(kotlin(Classpath.kotlin, Version.kotlin))
+        classpath(Classpath.bintray)
     }
 }
 
@@ -15,6 +15,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { setUrl("https://dl.bintray.com/spekframework/spek-dev") }
+        maven { setUrl(MavenUrl.spekDev) }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,12 @@
+repositories {
+  jcenter()
+}
+
+plugins {
+  `kotlin-dsl`
+  `java-gradle-plugin`
+}
+
+dependencies {
+  implementation(gradleApi())
+}

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,3 @@
-import org.gradle.kotlin.dsl.extra
-
 object Artifact {
   const val groupdId = "com.mercari.rxredux"
   const val version = "1.0.0-rc5"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,35 @@
+import org.gradle.kotlin.dsl.extra
 
 object Artifact {
   const val groupdId = "com.mercari.rxredux"
   const val version = "1.0.0-rc5"
+}
+
+object MavenUrl {
+  const val spekDev = "https://dl.bintray.com/spekframework/spek-dev"
+}
+
+object Version {
+  const val bintray = "1.8.4"
+  const val kotlin = "1.3.30"
+  const val rxJava = "2.2.9"
+  const val kluent = "1.49"
+  const val spek = "2.0.2"
+  const val jacoco = "0.8.4"
+}
+
+object Classpath {
+  const val kotlin = "gradle-plugin"
+  const val bintray = "com.jfrog.bintray.gradle:gradle-bintray-plugin:${Version.bintray}"
+}
+
+object Dependencies {
+  const val kotlin = "stdlib"
+  const val rxJava = "io.reactivex.rxjava2:rxjava:${Version.rxJava}"
+}
+
+object TestDependencies {
+  const val kluent = "org.amshove.kluent:kluent-android:${Version.kluent}"
+  const val spek = "org.spekframework.spek2:spek-dsl-jvm:${Version.spek}"
+  const val spekRunner = "org.spekframework.spek2:spek-runner-junit5:${Version.spek}"
 }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,0 +1,5 @@
+
+object Artifact {
+  const val groupdId = "com.mercari.rxredux"
+  const val version = "1.0.0-rc5"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,6 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 # Publishing
-artifactGroupId=com.mercari.rxredux
-artifactPublishVersion=1.0.0-rc5
 bintrayVersion=1.8.4
 
 # Compile

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,3 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-
-# Publishing
-bintrayVersion=1.8.4
-
-# Compile
-kotlinVersion=1.3.30
-rxJavaVersion=2.2.9
-
-# Test
-jacocoVersion=0.8.4
-kluentVersion=1.49
-spekVersion=2.0.2
-

--- a/rxredux/build.gradle.kts
+++ b/rxredux/build.gradle.kts
@@ -61,8 +61,9 @@ task<JacocoReport>("codeCoverageReport") {
     dependsOn(test)
 }
 
-val artifactGroupId = extra.get("artifactGroupId") as String
-val artifactPublishVersion = extra.get("artifactPublishVersion") as String
+//val artifactGroupId = extra.get("artifactGroupId") as String
+val artifactGroupId = Artifact.groupdId
+val artifactPublishVersion = Artifact.version
 
 group = artifactGroupId
 version = artifactPublishVersion

--- a/rxredux/build.gradle.kts
+++ b/rxredux/build.gradle.kts
@@ -12,20 +12,15 @@ repositories {
 }
 
 dependencies {
-    val kotlinVersion = extra.get("kotlinVersion")
-    val rxJavaVersion = extra.get("rxJavaVersion")
-
-    implementation(kotlin("stdlib", "$kotlinVersion"))
-    implementation("io.reactivex.rxjava2:rxjava:$rxJavaVersion")
+    implementation(kotlin(Dependencies.kotlin, Version.kotlin))
+    implementation(Dependencies.rxJava)
 
     // assertion
-    val kluentVersion = extra.get("kluentVersion")
-    testImplementation("org.amshove.kluent:kluent-android:$kluentVersion")
+    testImplementation(TestDependencies.kluent)
 
     // spek2
-    val spekVersion = extra.get("spekVersion")
-    testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
-    testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
+    testImplementation(TestDependencies.spek)
+    testRuntimeOnly(TestDependencies.spekRunner)
 }
 
 tasks.withType<Test> {
@@ -33,9 +28,7 @@ tasks.withType<Test> {
 }
 
 jacoco {
-    val jacocoVersion = extra.get("jacocoVersion") as String
-
-    toolVersion = jacocoVersion
+    toolVersion = Version.jacoco
 }
 
 task<JacocoReport>("codeCoverageReport") {


### PR DESCRIPTION
Before working on Gradle version bump (https://github.com/mercari/RxReduxK/pull/21), we need to migrate the way to access some properties in `gradle.properties`.