### PR TITLE
Migration to RxJava3

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -10,7 +10,7 @@ object MavenUrl {
 object Version {
   const val bintray = "1.8.4"
   const val kotlin = "1.3.30"
-  const val rxJava = "2.2.9"
+  const val rxJava = "3.0.0"
   const val kluent = "1.49"
   const val spek = "2.0.2"
   const val jacoco = "0.8.4"
@@ -23,7 +23,7 @@ object Classpath {
 
 object Dependencies {
   const val kotlin = "stdlib"
-  const val rxJava = "io.reactivex.rxjava2:rxjava:${Version.rxJava}"
+  const val rxJava = "io.reactivex.rxjava3:rxjava:${Version.rxJava}"
 }
 
 object TestDependencies {

--- a/rxredux/src/main/java/com/mercari/rxredux/RxRedux.kt
+++ b/rxredux/src/main/java/com/mercari/rxredux/RxRedux.kt
@@ -1,11 +1,11 @@
 package com.mercari.rxredux
 
-import io.reactivex.Observable
-import io.reactivex.Scheduler
-import io.reactivex.annotations.CheckReturnValue
-import io.reactivex.disposables.Disposable
-import io.reactivex.schedulers.Schedulers
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.rxjava3.annotations.CheckReturnValue
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import io.reactivex.rxjava3.subjects.PublishSubject
 
 interface Action
 
@@ -43,10 +43,10 @@ interface StoreType<S : State, A : Action> {
 }
 
 class Store<S : State, A : Action>(
-        initialState: S,
-        reducer: Reducer<S, A>,
-        defaultScheduler: Scheduler = Schedulers.single(),
-        serializeActions: Boolean = false
+    initialState: S,
+    reducer: Reducer<S, A>,
+    defaultScheduler: Scheduler = Schedulers.single(),
+    serializeActions: Boolean = false
 ) : StoreType<S, A> {
 
     // seed action

--- a/rxredux/src/test/java/com/mercari/rxredux/MultiThreadTest.kt
+++ b/rxredux/src/test/java/com/mercari/rxredux/MultiThreadTest.kt
@@ -1,6 +1,6 @@
 package com.mercari.rxredux
 
-import io.reactivex.Observable
+import io.reactivex.rxjava3.core.Observable
 import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldEqual
 import org.spekframework.spek2.Spek

--- a/rxredux/src/test/java/com/mercari/rxredux/RxReduxTest.kt
+++ b/rxredux/src/test/java/com/mercari/rxredux/RxReduxTest.kt
@@ -1,7 +1,11 @@
 package com.mercari.rxredux
 
-import io.reactivex.Observable
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.schedulers.Schedulers
 import org.amshove.kluent.shouldBeInstanceOf
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldEqual
@@ -94,7 +98,7 @@ class ReduxTest : Spek({
                 val obs = Observable.just(Decrement(23))
                 store.dispatch(obs)
 
-                val lastIndex = test.valueCount() - 1
+                val lastIndex = test.values().size - 1
                 test.assertValueAt(lastIndex) { (it.counter == -22).shouldBeTrue() }
             }
 
@@ -105,7 +109,7 @@ class ReduxTest : Spek({
 
                 store.dispatch(ob1, ob2, ob3)
 
-                val lastIndex = test.valueCount() - 1
+                val lastIndex = test.values().size - 1
                 test.values()[lastIndex].counter shouldEqual -19
             }
 
@@ -145,7 +149,7 @@ class ReduxTest : Spek({
 
                 localSubscriber.assertValueCount(4)
 
-                localSubscriber.cancel()
+                localSubscriber.dispose()
 
                 store.dispatch(Increment(2))
                 store.dispatch(Decrement(3))


### PR DESCRIPTION
Migration Note: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-3.0