### PR TITLE
Update Spek to 2.0.10

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -12,7 +12,7 @@ object Version {
   const val kotlin = "1.3.30"
   const val rxJava = "2.2.9"
   const val kluent = "1.49"
-  const val spek = "2.0.2"
+  const val spek = "2.0.10"
   const val jacoco = "0.8.4"
 }
 


### PR DESCRIPTION
We have bunch of updates on Spek APIs but it seems that we don't have any issues for changes in the library.