### PR TITLE
Remove Codecov usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,6 @@ jobs:
 
       - run: ./gradlew codeCoverageReport
 
-      - run: bash <(curl -s https://codecov.io/bash)
-
   deploy:
     <<: *jdk_env
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![jcenter](https://api.bintray.com/packages/mercari-inc/maven/rxreduxk/images/download.svg)](https://bintray.com/mercari-inc/maven/rxreduxk/_latestVersion)
 [![Build Status](https://circleci.com/gh/mercari/RxReduxK.svg?style=svg)](https://circleci.com/gh/mercari/RxReduxK)
-[![codecov](https://codecov.io/gh/mercari/rxreduxk/branch/master/graph/badge.svg)](https://codecov.io/gh/mercari/RxReduxK)
 
 Micro-framework for Redux implemented in Kotlin
 


### PR DESCRIPTION
We'd remove Codecov usage as our company policy.

I left the command `codeCoverageReport` since it is a task which just generates a coverage report: https://github.com/mercari/RxReduxK/blob/b947d494b88984e45711c734a9153c012955192b/.circleci/config.yml#L36